### PR TITLE
Updating the Interceptor to work with Dio >=3.0

### DIFF
--- a/lib/instabug_dio_interceptor.dart
+++ b/lib/instabug_dio_interceptor.dart
@@ -6,20 +6,23 @@ class InstabugDioInterceptor extends Interceptor {
   static final Map<int, NetworkData> _requests = <int, NetworkData>{};
 
   @override
-  dynamic onRequest(RequestOptions options) {
+  onRequest(RequestOptions options) {
     final NetworkData data = NetworkData();
     data.startTime = DateTime.now();
     _requests[options.hashCode] = data;
+    return super.onRequest(options);
   }
 
   @override
-  dynamic onResponse(Response response) {
+  onResponse(Response response) {
     NetworkLogger.networkLog(_map(response));
+    return super.onResponse(response);
   }
 
   @override
-  dynamic onError(DioError err) {
+  onError(DioError err) {
     NetworkLogger.networkLog(_map(err.response));
+    return super.onError(err);
   }
 
   static NetworkData _getRequestData(int requestHashCode) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dio: ^2.1.7
-  instabug_flutter: ^1.0.0
+  dio: ">=3.0.0"
+  instabug_flutter: ">=9.0.0"
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
I took a stab at updating the pubspec.yaml as well; not sure if I did that correctly. But had to change the type to Future to pass static type checker and then needed the super call otherwise it seemed like the requests and responses were being dropped.

After making those changes I can now use the interceptor with Dio v3.0+ and also verified that my Network Logs showed up in the Instabug dashboard!