### PR TITLE
[MOB-6001] APM Network Requests not showing in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.0.1 (2021-09-29)
+
+* Fixes an issue with APM network logger not reporting to the dashboard
+
 ## v2.0.0 (2021-09-20)
 
 * Adds support for Dio v4.0

--- a/lib/instabug_dio_interceptor.dart
+++ b/lib/instabug_dio_interceptor.dart
@@ -4,7 +4,7 @@ import 'package:instabug_flutter/NetworkLogger.dart';
 
 class InstabugDioInterceptor extends Interceptor {
   static final Map<int, NetworkData> _requests = <int, NetworkData>{};
-
+  
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     final NetworkData data = NetworkData(
@@ -42,12 +42,14 @@ class InstabugDioInterceptor extends Interceptor {
   NetworkData _map(Response<dynamic> response) {
     final NetworkData data = _getRequestData(response.requestOptions.hashCode);
     final Map<String, dynamic> responseHeaders = <String, dynamic>{};
+    final DateTime endTime = DateTime.now();
+
     response.headers
         .forEach((String name, dynamic value) => responseHeaders[name] = value);
     return data.copyWith(
-      endTime: DateTime.now(),
-      duration: data.endTime != null
-          ? data.endTime!.millisecondsSinceEpoch -
+      endTime: endTime,
+      duration: endTime != null
+          ? endTime.millisecondsSinceEpoch -
               data.startTime.millisecondsSinceEpoch
           : 0,
       url: response.requestOptions.uri.toString(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: instabug_dio_interceptor
 description: This package is an add on to instabug_flutter. It intercepts any requests performed 
             with Dio Package and sends them to the report that will be sent to the dashboard.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/Instabug/Instabug-Flutter#readme 
 
 environment:


### PR DESCRIPTION
## Description of the change
Fixed network requests not showing in IBG dashboard.
## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
https://github.com/Instabug/Instabug-Flutter/issues/196#issuecomment-920934280
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
