### PR TITLE
[MOB-9346] Use `flutter pub get` instead of `pub get`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: flutter doctor
-      - run: pub get
+      - run: flutter pub get
       - run: flutter test
       - run: dartanalyzer --options analysis_options.yaml --fatal-warnings lib
       - run: flutter pub publish --dry-run


### PR DESCRIPTION
## Description of the change
- Use `flutter pub get` command instead of the outdated `pub get` (fixes this [error](https://app.circleci.com/pipelines/github/Instabug/Instabug-Dio-Interceptor/41/workflows/2a20d56b-f81f-4f04-995f-c73f349b4873/jobs/52))
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
