### PR TITLE
[MOB-12123] Use `init` in Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - checkout
       - run: flutter doctor
       - run: flutter pub get
+      - run: flutter pub run build_runner build --delete-conflicting-outputs
       - run: flutter test
       - run: flutter analyze .
       - run: flutter pub publish --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated files
+*.mocks.dart
+
 # Miscellaneous
 *.class
 *.lock

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,7 +63,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
           ],
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,11 +6,10 @@ import 'package:instabug_flutter/instabug_flutter.dart';
 Future<void> main() async {
   runApp(const MyApp());
 
-  Instabug.start(
-    'ed6f659591566da19b67857e1b9d40ab',
-    [InvocationEvent.floatingButton],
+  Instabug.init(
+    token: 'ed6f659591566da19b67857e1b9d40ab',
+    invocationEvents: [InvocationEvent.floatingButton],
   );
-  
 
   final dio = Dio()..interceptors.add(InstabugDioInterceptor());
   final response = await dio.get('https://google.com');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,10 @@ dependencies:
   instabug_flutter: '>=11.0.0 <12.0.0'
 
 dev_dependencies:
+  build_runner: ^2.0.3
   flutter_test:
     sdk: flutter
+  mockito: 5.2.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/instabug_dio_interceptor_test.dart
+++ b/test/instabug_dio_interceptor_test.dart
@@ -1,10 +1,12 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:instabug_dio_interceptor/instabug_dio_interceptor.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:instabug_flutter/src/generated/instabug.api.g.dart';
+import 'package:mockito/annotations.dart';
 
+import 'instabug_dio_interceptor_test.mocks.dart';
 import 'mock_adapter.dart';
 
 class MyInterceptor extends InstabugDioInterceptor {
@@ -32,23 +34,24 @@ class MyInterceptor extends InstabugDioInterceptor {
   }
 }
 
+@GenerateMocks(<Type>[
+  InstabugHostApi,
+])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   WidgetsFlutterBinding.ensureInitialized();
+
+  final MockInstabugHostApi mHost = MockInstabugHostApi();
+
   late Dio dio;
   late MyInterceptor instabugDioInterceptor;
   const String appToken = '068ba9a8c3615035e163dc5f829c73be';
-  setUpAll(() async {
-    const MethodChannel('instabug_flutter')
-        .setMockMethodCallHandler((MethodCall methodCall) async {
-      switch (methodCall.method) {
-        case 'getTags':
-          return <String>['tag1', 'tag2'];
-        default:
-          return null;
-      }
-    });
+
+  setUpAll(() {
+    Instabug.$setHostApi(mHost);
+    NetworkLogger.$setHostApi(mHost);
   });
+
   setUp(() {
     dio = Dio();
     dio.options.baseUrl = MockAdapter.mockBase;

--- a/test/instabug_dio_interceptor_test.dart
+++ b/test/instabug_dio_interceptor_test.dart
@@ -56,7 +56,7 @@ void main() {
     final List<InvocationEvent> events = <InvocationEvent>[];
     instabugDioInterceptor = MyInterceptor();
     dio.interceptors.add(instabugDioInterceptor);
-    Instabug.start(appToken, events);
+    Instabug.init(token: appToken, invocationEvents: events);
   });
 
   test('onResponse Test', () async {


### PR DESCRIPTION
## Description of the change
- Replace `start` with `init` in tests
- Update mocking technique to suit pigeon's migration
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues
> Issue links go here
## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
