### PR TITLE
refactor!: use `DioException` instead of deprecated `DioError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for Instabug Flutter SDK v12 ([#26](https://github.com/Instabug/Instabug-Dio-Interceptor/pull/26)), closes [#25](https://github.com/Instabug/Instabug-Dio-Interceptor/issues/25).
 
+### Changed
+
+- **BREAKING:** Drop support for Dio versions before v5.2.0 to use `DioException` instead of the deprecated `DioError` ([#27](https://github.com/Instabug/Instabug-Dio-Interceptor/pull/27)).
+
 ## v2.2.0 (2022-03-14)
 
 - Adds support for Dio v5

--- a/lib/instabug_dio_interceptor.dart
+++ b/lib/instabug_dio_interceptor.dart
@@ -23,9 +23,7 @@ class InstabugDioInterceptor extends Interceptor {
   }
 
   @override
-  // Keep `DioError` instead of `DioException` for backward-compatibility, for now.
-  // ignore: deprecated_member_use
-  void onError(DioError err, ErrorInterceptorHandler handler) {
+  void onError(DioException err, ErrorInterceptorHandler handler) {
     if (err.response != null) {
       final NetworkData data = _map(err.response!);
       _networklogger.networkLog(data);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  dio: '>=4.0.0 <6.0.0'
+  dio: '>=5.2.0 <6.0.0'
   flutter:
     sdk: flutter
   instabug_flutter: '>=11.0.0 <13.0.0'

--- a/test/instabug_dio_interceptor_test.dart
+++ b/test/instabug_dio_interceptor_test.dart
@@ -28,8 +28,7 @@ class MyInterceptor extends InstabugDioInterceptor {
   }
 
   @override
-  // ignore: deprecated_member_use
-  void onError(DioError err, ErrorInterceptorHandler handler) {
+  void onError(DioException err, ErrorInterceptorHandler handler) {
     errorCount++;
     super.onError(err, handler);
   }
@@ -66,8 +65,7 @@ void main() {
   test('onResponse Test', () async {
     try {
       await dio.get<dynamic>('/test');
-      // ignore: deprecated_member_use
-    } on DioError {
+    } on DioException {
       // ignor
     }
 
@@ -79,8 +77,7 @@ void main() {
   test('onError Test', () async {
     try {
       await dio.get<dynamic>('/test-error');
-      // ignore: deprecated_member_use
-    } on DioError {
+    } on DioException {
       // ignor
     }
 
@@ -93,8 +90,7 @@ void main() {
     for (int i = 0; i < 1000; i++) {
       try {
         await dio.get<dynamic>('/test');
-        // ignore: deprecated_member_use
-      } on DioError {
+      } on DioException {
         // ignor
       }
     }


### PR DESCRIPTION
## Description of the change

Use `DioException` instead of the deprecated `DioError` which requires dropping support for Dio versions before 5.2.0 which is a breaking change.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: MOB-13757

## Checklists
### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] Issue from task tracker has a link to this pull request 
